### PR TITLE
Prevent storing too much data in cookies

### DIFF
--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -251,8 +251,8 @@ const register = function (server, options) {
 
                 const authInfo = {
                     user_name,
-                    backend_roles,
-                    roles,
+                    // backend_roles,
+                    // roles,
                     tenants,
                     user_requested_tenant
                 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendistro_security",
-  "version": "6.8.1",
+  "version": "6.8.10",
   "description": "Security features for kibana",
   "main": "index.js",
   "homepage": "https://github.com/opendistro-for-elasticsearch/security-kibana-plugin",


### PR DESCRIPTION
Previously if a user had many backend roles it was creating a cookie
too large for loadbalancers and browers
