### PR TITLE
 Prevent storing too much data in cookies

### DIFF
--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -259,8 +259,8 @@ const register = function (server, options) {
 
                 const authInfo = {
                     user_name,
-                    backend_roles,
-                    roles,
+                    // backend_roles,
+                    // roles,
                     tenants,
                     user_requested_tenant
                 };


### PR DESCRIPTION
Previously if a user had many backend roles it was creating a cookie
too large for loadbalancers and browers
